### PR TITLE
Fix: integrar dados da Câmara nas proposições

### DIFF
--- a/docs/productivity/metrics.json
+++ b/docs/productivity/metrics.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-30T03:12:20.572230+00:00",
+  "generated_at": "2026-06-30T15:25:14.858193+00:00",
   "repo": "unb-mds/2026-1-Guard.IA",
   "branches": [
     "dev-projeto",
@@ -18,6 +18,8 @@
     "feat/teste-pipeline-unificado",
     "filtragem",
     "filtragem-B",
+    "fix/camara-proposicoes-data",
+    "fix/main",
     "main",
     "pages-metricas",
     "release-1-integration",
@@ -35,12 +37,12 @@
     "revert-48-feat/nova-pagina-dashboard"
   ],
   "summary": {
-    "total_commits": 352,
+    "total_commits": 353,
     "open_issues": 3,
     "closed_issues": 36,
     "contributors": 8,
-    "open_prs": 1,
-    "branches_ativas": 20,
+    "open_prs": 2,
+    "branches_ativas": 22,
     "branches_deletadas": 9
   },
   "branches_data": {
@@ -266,6 +268,35 @@
           "char_count": 16
         }
       ]
+    },
+    "fix/camara-proposicoes-data": {
+      "branch": "fix/camara-proposicoes-data",
+      "total_commits": 1,
+      "commits_per_author": {
+        "lucasnferreiradev-lang": 1
+      },
+      "commit_timeline": [
+        {
+          "date": "2026-06-30",
+          "count": 1
+        }
+      ],
+      "recent_commits": [
+        {
+          "sha": "9ffa764",
+          "author": "lucasnferreiradev-lang",
+          "date": "2026-06-30T15:23:49+00:00",
+          "message": "Fix: fill Câmara proposal state data",
+          "char_count": 36
+        }
+      ]
+    },
+    "fix/main": {
+      "branch": "fix/main",
+      "total_commits": 0,
+      "commits_per_author": {},
+      "commit_timeline": [],
+      "recent_commits": []
     },
     "main": {
       "branch": "main",
@@ -1895,6 +1926,16 @@
   },
   "pull_requests": [
     {
+      "number": 65,
+      "title": "Fix: integrar dados da Câmara nas proposições",
+      "state": "open",
+      "base": "main",
+      "head": "fix/camara-proposicoes-data",
+      "author": "LucasNF-Dev",
+      "created_at": "2026-06-30T15:24:02+00:00",
+      "merged_at": null
+    },
+    {
       "number": 63,
       "title": "Feat/integracao proposicoes ",
       "state": "closed",
@@ -2149,7 +2190,7 @@
     "claranunes22": 151,
     "PajeMurici-dev": 67,
     "gabiiverissimo-dev": 44,
-    "lucasnferreiradev-lang": 30,
+    "lucasnferreiradev-lang": 31,
     "otaviotex": 24,
     "LucasNF-Dev": 20,
     "AlmondHare": 14,
@@ -2176,6 +2217,10 @@
       "filtragem-B": 2,
       "main": 12
     },
+    "lucasnferreiradev-lang": {
+      "fix/camara-proposicoes-data": 1,
+      "main": 30
+    },
     "PajeMurici-dev": {
       "main": 58,
       "release-1-integration": 4,
@@ -2192,9 +2237,6 @@
       "feat/login-page": 3,
       "feat/login-redesign": 2,
       "revert-48-feat/nova-pagina-dashboard": 1
-    },
-    "lucasnferreiradev-lang": {
-      "main": 30
     },
     "LucasNF-Dev": {
       "main": 19,

--- a/grupo5-guard.ia-backend/app/coleta/coletor_camara.py
+++ b/grupo5-guard.ia-backend/app/coleta/coletor_camara.py
@@ -3,6 +3,10 @@ import json
 import time
 from pathlib import Path
 
+
+DETAILS_URL = "https://dadosabertos.camara.leg.br/api/v2/proposicoes/{id}/autores"
+DEPUTADO_URL = "https://dadosabertos.camara.leg.br/api/v2/deputados/{id}"
+
 # Configurações e Caminhos
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 DATA_DIR = BASE_DIR / "data"
@@ -74,6 +78,60 @@ def format_proposicao(prop, detalhes):
         "data_apresentacao": prop.get("dataApresentacao", "")
     }
 
+
+def buscar_detalhes_proposicao(proposicao_id):
+    detalhes_placeholder = {
+        "autor": "A pesquisar",
+        "partido": "A pesquisar",
+        "estado": "A pesquisar"
+    }
+
+    try:
+        response = requests.get(
+            DETAILS_URL.format(id=proposicao_id),
+            headers=HEADERS,
+            timeout=30,
+        )
+        response.raise_for_status()
+        dados = response.json().get("dados", [])
+        if not dados:
+            return detalhes_placeholder
+
+        autor = dados[0]
+        nome_autor = autor.get("nome") or autor.get("nomeAutor")
+        partido = autor.get("siglaPartido")
+        estado = autor.get("siglaUf")
+
+        if not partido and not estado and autor.get("uri"):
+            uri = autor.get("uri") or ""
+            if "/deputados/" in uri:
+                deputado_id = uri.rstrip("/").split("/")[-1]
+                try:
+                    dep_response = requests.get(
+                        DEPUTADO_URL.format(id=deputado_id),
+                        headers=HEADERS,
+                        timeout=30,
+                    )
+                    dep_response.raise_for_status()
+                    dep_data = dep_response.json().get("dados", {})
+                    ultimo_status = dep_data.get("ultimoStatus", {})
+                    partido = ultimo_status.get("siglaPartido") or partido
+                    estado = ultimo_status.get("siglaUf") or estado
+                    if not nome_autor:
+                        nome_autor = ultimo_status.get("nome") or dep_data.get("nomeCivil")
+                except Exception:
+                    pass
+
+        return {
+            "autor": nome_autor or "A pesquisar",
+            "partido": partido or "A pesquisar",
+            "estado": estado or "A pesquisar",
+        }
+    except Exception as e:
+        print(f"⚠️ Não foi possível buscar detalhes da proposição {proposicao_id}: {e}")
+        return detalhes_placeholder
+
+
 def coletar():
     checkpoint = load_checkpoint()
     data_inicio = checkpoint["last_date"]
@@ -118,13 +176,8 @@ def coletar():
                 if id_ext in ids_existentes:
                     continue
 
-                detalhes_placeholder = {
-                    "autor": "A pesquisar",
-                    "partido": "A pesquisar",
-                    "estado": "A pesquisar"
-                }
-
-                proposicao_formatada = format_proposicao(prop, detalhes_placeholder)
+                detalhes = buscar_detalhes_proposicao(id_prop)
+                proposicao_formatada = format_proposicao(prop, detalhes)
                 proposicoes_do_lote.append(proposicao_formatada)
                 ids_existentes.add(id_ext)
 

--- a/grupo5-guard.ia-backend/tests/test_coletor_camara.py
+++ b/grupo5-guard.ia-backend/tests/test_coletor_camara.py
@@ -1,0 +1,37 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.coleta import coletor_camara
+
+
+class ColetorCamaraTests(unittest.TestCase):
+    def test_buscar_detalhes_proposicao_extrae_estado_do_autor(self):
+        mock_response = {
+            "dados": [
+                {
+                    "id": 12345,
+                    "nome": "Maria Souza",
+                    "siglaPartido": "PSOL",
+                    "siglaUf": "DF",
+                    "uri": "https://dadosabertos.camara.leg.br/api/v2/deputados/99999",
+                }
+            ]
+        }
+
+        with patch("app.coleta.coletor_camara.requests.get") as mock_get:
+            mock_get.return_value.json.return_value = mock_response
+            mock_get.return_value.raise_for_status.return_value = None
+
+            detalhes = coletor_camara.buscar_detalhes_proposicao(12345)
+
+        self.assertEqual(detalhes["autor"], "Maria Souza")
+        self.assertEqual(detalhes["partido"], "PSOL")
+        self.assertEqual(detalhes["estado"], "DF")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Resumo
- Ajusta o coletor da Câmara para preencher autor, partido e estado com dados reais quando disponíveis.
- Remove a dependência de placeholders como 'A pesquisar' para o fluxo de proposições.
- Adiciona teste de regressão para validar o parsing dos dados da Câmara.

## Validação
- python -m unittest -q tests.test_coletor_camara